### PR TITLE
fix: use static remote deps and skip early days

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "start": "nodemon --watch ./src/server",
     "watch": "webpack --watch",
     "docker:build": "npm run lint && webpack && docker build -t sf-visualizations:latest .",
-    "docker:run": "docker run -d --name sf-visualizations -p 8081:8080 sf-visualizations:latest",
-    "docker:kill": "docker kill sf-visualizations",
+    "docker:run": "docker run -d --name sf-visualizations -p 9081:8080 sf-visualizations:latest",
+    "docker:kill": "docker kill sf-visualizations; docker rm sf-visualizations",
     "docker:push": "docker tag sf-visualizations:latest ghmeier/sf-visualizations:latest && docker push ghmeier/sf-visualizations:latest"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "nodemon --watch ./src/server",
     "watch": "webpack --watch",
     "docker:build": "npm run lint && webpack && docker build -t sf-visualizations:latest .",
-    "docker:run": "docker run -d --name sf-visualizations -p 9081:8080 sf-visualizations:latest",
+    "docker:run": "docker run -d --name sf-visualizations -p 8081:8080 sf-visualizations:latest",
     "docker:kill": "docker kill sf-visualizations; docker rm sf-visualizations",
     "docker:push": "docker tag sf-visualizations:latest ghmeier/sf-visualizations:latest && docker push ghmeier/sf-visualizations:latest"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,10 +17,10 @@ module.exports = {
       template: require('html-webpack-template'),
 
       scripts: [
-        'https://unpkg.com/react@16/umd/react.development.js',
-        'https://unpkg.com/react-dom@16/umd/react-dom.development.js',
+        'https://unpkg.com/react@16.14.0/umd/react.production.min.js',
+        'https://unpkg.com/react-dom@16.14.0/umd/react-dom.production.min.js',
         'https://unpkg.com/prop-types/prop-types.min.js',
-        'https://unpkg.com/recharts/umd/Recharts.min.js',
+        'https://unpkg.com/recharts@2.0.8/umd/Recharts.min.js',
         'build-main.js',
       ],
       links: [


### PR DESCRIPTION
This starts the calculations at the same date on each chart bot skipping
some early pandemic days with inconsistent data and ensuring the dates
are the same on all.